### PR TITLE
Enable Home Assistant voice control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-# Obsidian Sample Plugin
+# Home Assistant Voice Plugin
 
-This is a sample plugin for Obsidian (https://obsidian.md).
+This plugin exposes a small HTTP API so you can control your vault from the Home Assistant voice assistant.
+
+POST `/command` expects JSON with a `text` field. Some example phrases:
+
+- `create note shopping`
+- `append to shopping: buy milk`
+- `read note shopping`
+- `list notes`
+- `search for project`
 
 This project uses TypeScript to provide type checking and documentation.
 The repo depends on the latest plugin API (obsidian.d.ts) in TypeScript Definition format, which contains TSDoc comments describing what it does.

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-	"id": "sample-plugin",
-	"name": "Sample Plugin",
+    "id": "ha-voice-plugin",
+    "name": "Home Assistant Voice Plugin",
 	"version": "1.0.0",
 	"minAppVersion": "0.15.0",
-	"description": "Demonstrates some of the capabilities of the Obsidian API.",
-	"author": "Obsidian",
-	"authorUrl": "https://obsidian.md",
+    "description": "Control your vault via Home Assistant voice commands.",
+    "author": "Obsidian",
+    "authorUrl": "https://obsidian.md",
 	"fundingUrl": "https://obsidian.md/pricing",
 	"isDesktopOnly": false
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "strictNullChecks": true,
     "lib": [
       "DOM",


### PR DESCRIPTION
## Summary
- rename plugin and manifest to **Home Assistant Voice Plugin**
- expose a tiny HTTP server to receive commands from Home Assistant
- add server port setting
- update README with basic usage instructions
- allow ES module interop for Node builtins

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849c66650d48327929455f1c96cf607